### PR TITLE
Update mappings for SKUs to categories

### DIFF
--- a/functions/processdata.js
+++ b/functions/processdata.js
@@ -121,6 +121,10 @@ processAll = async function(org, date)
             then: 'audit'
           },
           {
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'ATLAS_SUPPORT' }},
+            then: 'support'
+          },
+          {
             case: { $regexMatch: { input: '$lineItems.sku', regex: 'FREE_SUPPORT' }},
             then: 'free support'
           },
@@ -130,7 +134,11 @@ processAll = async function(org, date)
           },
           {
             case: { $regexMatch: { input: '$lineItems.sku', regex: 'STITCH' }},
-            then: 'stitch'
+            then: 'realm'
+          },
+          {
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'SERVERLESS' }},
+            then: 'serverless'
           },
           {
             case: { $regexMatch: { input: '$lineItems.sku', regex: 'SECURITY' }},


### PR DESCRIPTION
Changes to the code that maps raw line item SKUs to categories:

- New categories for Support and Serverless
- Changed "stitch" category to "realm" to reflect current service names.