### PR TITLE
Reliablity improvements

### DIFF
--- a/functions/getall.js
+++ b/functions/getall.js
@@ -1,6 +1,6 @@
 exports = async function(){
  const promises = [
-   //TO BE UPDATED IF YOU HAVE SEVERAL ORGANISATION
+   //If you want to include several orgs in the one dashboard, you'll need to call getdata_latest for each one, with appropriate org IDs and API keys.
    
     context.functions.execute("getdata_latest", context.values.get("billing-org"), context.values.get("billing-username"), context.values.get("billing-password"))
       .catch(err => { return err; }),

--- a/functions/processdata.js
+++ b/functions/processdata.js
@@ -133,7 +133,7 @@ processAll = async function(org, date)
             then: 'charts'
           },
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: 'STITCH' }},
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'REALM' }},
             then: 'app services'
           },
           {

--- a/functions/processdata.js
+++ b/functions/processdata.js
@@ -84,16 +84,16 @@ processAll = async function(org, date)
         default: 'n/a'
       }
     },
-    instance: { '$ifNull': [{ '$arrayElemAt': [ { '$split': ['$lineItems.sku', ' '] }, 1 ] }, 'non-instance']},
+    instance: { '$ifNull': [{ '$arrayElemAt': [ { '$split': ['$lineItems.sku', '_INSTANCE_'] }, 1 ] }, 'non-instance']},
     category: {
       '$switch': {
         branches: [
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: "Instance" }},
+            case: { $regexMatch: { input: '$lineItems.sku', regex: "_INSTANCE" }},
             then: 'instances'
           },
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: 'Backup' }},
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'BACKUP' }},
             then: 'backup'
           },
           {
@@ -101,7 +101,7 @@ processAll = async function(org, date)
             then: 'backup'
           },
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: 'Transfer' }},
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'DATA_TRANSFER' }},
             then: 'data xfer'
           },
           {
@@ -109,7 +109,7 @@ processAll = async function(org, date)
             then: 'storage'
           },
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: 'BI Connector' }},
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'BI_CONNECTOR' }},
             then: 'bi connector'
           },
           {
@@ -117,7 +117,7 @@ processAll = async function(org, date)
             then: 'data lake'
           },
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: 'Auditing' }},
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'AUDITING' }},
             then: 'audit'
           },
           {
@@ -129,23 +129,23 @@ processAll = async function(org, date)
             then: 'free support'
           },
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: 'Charts' }},
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'CHARTS' }},
             then: 'charts'
           },
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: 'Compute' }},
-            then: 'realm'
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'STITCH' }},
+            then: 'app services'
           },
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: 'Serverless' }},
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'SERVERLESS' }},
             then: 'serverless'
           },
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: 'Security' }},
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'SECURITY' }},
             then: 'security'
           },
           {
-            case: { $regexMatch: { input: '$lineItems.sku', regex: 'Endpoint' }},
+            case: { $regexMatch: { input: '$lineItems.sku', regex: 'PRIVATE_ENDPOINT' }},
             then: 'private endpoint'
           },
         ],


### PR DESCRIPTION
Made the following changes:
 - Any errors from `getAll` are now returned in the status output
 - Nulled out the `linkedInvoice` field from the raw invoices returned from the API, since these can be very large
 - Reverted last PR for parsing SKU codes, since the API is now using the original values.