### PR TITLE
Performance and memory optimisations

### DIFF
--- a/functions/getOrgData.js
+++ b/functions/getOrgData.js
@@ -33,7 +33,7 @@ getInvoices = async function(org, username, password)
 
   let promises = [];
   body.results.forEach(result => {
-    const invoice = invoicedata.find(elem => elem._id === result.id);
+    const invoice = invoicedata.find(elem => elem._id.toString() === result.id);
      
     if (result.statusName == "PENDING" || invoice === undefined || (invoicedata[0] && result.updated >= invoicedata[0].updated)) {
   
@@ -68,7 +68,7 @@ getInvoice = async function(org, username, password, invoiceId)
     }
   });
   body.lineItems = billedLineItems;
-  body._id = body.id;
+  body._id = new BSON.ObjectId(body.id);
   delete body.id;
   
   if (response.statusCode != 200) throw {"error": body.detail, "fn": "getInvoice", "statusCode": response.statusCode};


### PR DESCRIPTION
Updated `getOrgData` so it only pulls the invoices that match those in the API payload. Also we are now searching by `_id` so can make use of the index. 

Updated `processOrgData` to search for the most recent month of data via the ObjectID _id values, so we can use the default index.