### PR TITLE
Support for larger invoices

### DIFF
--- a/functions/getOrgData.js
+++ b/functions/getOrgData.js
@@ -13,7 +13,7 @@ getInvoices = async function(org, username, password)
   
   const refresh = context.values.get(`refreshInvoiceData`);
   if (!refresh) return Promise.resolve();
-
+ 
   const args = {
     "scheme": `https`,
     "host": `cloud.mongodb.com`,
@@ -22,7 +22,7 @@ getInvoices = async function(org, username, password)
     "digestAuth": true,
     "path": `/api/atlas/v1.0/orgs/${org}/invoices`
   };
-
+ 
   const response = await context.http.get(args);
   const body = JSON.parse(response.body.text());
   if (response.statusCode != 200) throw {"error": body.detail, "fn": "getInvoices", "statusCode": response.statusCode};
@@ -30,23 +30,25 @@ getInvoices = async function(org, username, password)
   const collection = context.services.get(`mongodb-atlas`).db(`billing`).collection(`billingdata`);
   const idList = body.results.map(item => item.id );
   const invoicedata = await collection.find({ _id: { "$in": idList}}, {"_id": 1, "updated": 1}).sort({"updated":-1}).toArray();
-
-  let promises = [];
-  body.results.forEach(result => {
+ 
+  for (const result of  body.results) {
     const invoice = invoicedata.find(elem => elem._id.toString() === result.id);
      
     if (result.statusName == "PENDING" || invoice === undefined || (invoicedata[0] && result.updated >= invoicedata[0].updated)) {
-  
-      promises.push(getInvoice(org, username, password, result.id));
+      try {
+        await getInvoice(org, username, password, result.id);
+      } catch (e) {
+        return e.toString();
+      }
     }
-  });
-  return Promise.all(promises.map(p => p.catch(e => e.toString())));
+  }
 };
 
 getInvoice = async function(org, username, password, invoiceId)
 { 
+  console.log("getInvoice: ", invoiceId)
   const collection = context.services.get(`mongodb-atlas`).db(`billing`).collection(`billingdata`);
-
+ 
   const args = {
     "scheme": `https`,
     "host": `cloud.mongodb.com`,
@@ -57,13 +59,22 @@ getInvoice = async function(org, username, password, invoiceId)
   };
   
   const response = await context.http.get(args);
-  const body = JSON.parse(response.body.text());
+  const txt = response.body.text()
+  console.log(" "); // Don't remove; needed to split up commands that prevents memory overruns
+  const body = JSON.parse(txt);
   body.linkedInvoices = null; // Potentially large, and not needed.
   
   // Remove zero dollar line items to save space
   const billedLineItems = [];
   body.lineItems.forEach(li => {
     if (li.totalPriceCents > 0) {
+      // For very large invoices, remove some detail to try to keep doc under 16MB
+      if (body.lineItems.length > 5000) {
+        delete li.unitPriceDollars;
+        delete li.created;
+        delete li.endDate;
+        delete li.unit;
+      }
       billedLineItems.push(li);
     }
   });
@@ -72,7 +83,7 @@ getInvoice = async function(org, username, password, invoiceId)
   delete body.id;
   
   if (response.statusCode != 200) throw {"error": body.detail, "fn": "getInvoice", "statusCode": response.statusCode};
-  return collection.replaceOne({"_id": body._id}, body, {"upsert": true});
+ return collection.replaceOne({"_id": body._id}, body, {"upsert": true});
 };
 
 getOrg = async function(org, username, password)

--- a/functions/processOrgData.js
+++ b/functions/processOrgData.js
@@ -28,6 +28,9 @@ processAll = async function(org, date)
     pipeline.push({ "$match": { "_id": { "$gte": objectIdFromTimestamp(startfrom) }}});
   }
 
+  // Process invoices in date order
+  pipeline.push({ "$sort": { "_id": 1 }});
+
   pipeline.push({ "$lookup": {
     "from": "orgdata",
     "localField": "orgId",
@@ -45,10 +48,6 @@ processAll = async function(org, date)
   if (date instanceof Date) {
     pipeline.push({ "$match": { "date": { "$gt": date }}});
   }
-  
-  // without a sort we're reliant on the data being presented in sorted order
-  // but without spilling to disk this sort stage falls over on the larger result sets
-  // pipeline.push({ "$sort": { "lineItems.startDate": 1 }});
 
   pipeline.push({ "$project": {
     "_id": 0,


### PR DESCRIPTION
Handles large invoices by:
- Forcing the download and parsing of invoices into two operations, minimising the memory usage
- Removing some details from the line items, giving us more headroom before we hit the 16MB document limit
- Adding a _id sort when processing invoices so they are done in chronological order, allowing for recovery after failure. 